### PR TITLE
ci(security): add and harden security scan workflows

### DIFF
--- a/.github/osv-scanner-config.toml
+++ b/.github/osv-scanner-config.toml
@@ -1,0 +1,6 @@
+# OSV Scanner configuration
+# To ignore a vulnerability, add an [[IgnoredVulns]] entry:
+# [[IgnoredVulns]]
+# id = "RUSTSEC-0000-0000"
+# reason = "Description of why this is ignored"
+# ignoreUntil = 2026-12-31T00:00:00Z

--- a/.github/workflows/check_security_vulnerability.yml
+++ b/.github/workflows/check_security_vulnerability.yml
@@ -14,10 +14,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: DevSkim
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       actions: read
       contents: read
@@ -27,8 +32,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          fetch-depth: 1
 
       - name: Run DevSkim scanner
+        # action pin via: git ls-remote https://github.com/microsoft/DevSkim-Action refs/tags/v1.0.16 | head -1
         uses: microsoft/DevSkim-Action@4b5047945a44163b94642a1cecc0d93a3f428cc6 # v1.0.16
 
       - name: Upload DevSkim scan results to GitHub Security tab

--- a/.github/workflows/osv-scan.yml
+++ b/.github/workflows/osv-scan.yml
@@ -1,0 +1,82 @@
+name: OSV Scanner
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "src/**"
+      - ".github/workflows/osv-scan.yml"
+      - ".github/osv-scanner-config.toml"
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "src/**"
+      - ".github/workflows/osv-scan.yml"
+      - ".github/osv-scanner-config.toml"
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  osv:
+    # Findings are informational — vulnerabilities surface in the GitHub Security
+    # tab via SARIF but do NOT fail the check.  To make them blocking, remove the
+    # exit-code 1 handling in the scanner step below.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        # action pin via: git ls-remote https://github.com/actions/checkout refs/tags/v6.0.2 | head -1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Prepare lockfile
+        # action pin via: git ls-remote https://github.com/dtolnay/rust-toolchain refs/heads/stable | head -1
+        uses: dtolnay/rust-toolchain@5d458579430fc14a04a08a1e7d3694f545e91ce6 # stable
+        with:
+          toolchain: stable
+
+      - name: Fetch dependencies
+        run: cargo fetch --locked
+
+      - name: Run OSV-Scanner (Docker, pinned digest)
+        # exit code 1 = vulnerabilities found (informational); other non-zero = scanner error (fatal)
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${{ github.workspace }}/osv-scan-output"
+          # Digest pinned via: docker pull ghcr.io/google/osv-scanner:latest && docker image inspect --format='{{index .RepoDigests 0}}' ghcr.io/google/osv-scanner:latest
+          docker run --rm \
+            -v "${{ github.workspace }}":/src:ro \
+            -v "${{ github.workspace }}/osv-scan-output":/out \
+            -w /src \
+            ghcr.io/google/osv-scanner@sha256:f7ba4be68bac8086b1f88fd598fdca1ca67239c79ad2c2b5c78e03a82e5187c4 \
+            --config .github/osv-scanner-config.toml \
+            --lockfile Cargo.lock \
+            --recursive \
+            --format sarif \
+            --output /out/osv-results.sarif || {
+            rc=$?
+            # exit code 1 = vulnerabilities found; upload SARIF and continue
+            [ "$rc" -eq 1 ] && exit 0
+            # any other non-zero exit code is a genuine scanner error
+            exit "$rc"
+          }
+
+      - name: Upload SARIF
+        # action pin via: git ls-remote https://github.com/github/codeql-action refs/tags/v4.35.1 | head -1
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        if: ${{ always() && hashFiles('osv-scan-output/osv-results.sarif') != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        with:
+          sarif_file: osv-scan-output/osv-results.sarif

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,52 @@
+name: SBOM (Syft)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - src/**
+      - .github/workflows/sbom.yml
+  push:
+    branches: [main]
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - src/**
+      - .github/workflows/sbom.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        # action pin via: git ls-remote https://github.com/actions/checkout refs/tags/v6.0.2 | head -1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Generate SBOM (repo)
+        # action pin via: git ls-remote https://github.com/anchore/sbom-action refs/tags/v0.17.10 | head -1
+        uses: anchore/sbom-action@8e94d75ddd33f69f691467e42275782e4bfefe84 # v0.17.10
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+
+      - name: Upload SBOM artifact
+        # action pin via: git ls-remote https://github.com/actions/upload-artifact refs/tags/v7.0.0 | head -1
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: sbom-${{ github.sha }}
+          path: sbom.cdx.json
+          retention-days: 7

--- a/.github/workflows/trivy-fs.yml
+++ b/.github/workflows/trivy-fs.yml
@@ -1,0 +1,78 @@
+name: Trivy FS Scan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "src/**"
+      - ".github/workflows/trivy-fs.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "src/**"
+      - ".github/workflows/trivy-fs.yml"
+
+permissions:
+  contents: read
+  security-events: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  trivy-fs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        # action pin via: git ls-remote https://github.com/actions/checkout refs/tags/v6.0.2 | head -1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Get current date for Trivy cache key
+        id: date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Cache Trivy vulnerability DB
+        # action pin via: git ls-remote https://github.com/actions/cache refs/tags/v4.2.2 | head -1
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        with:
+          path: ~/.cache/trivy
+          # Include a fragment of the pinned image digest so a digest bump busts the cache
+          key: trivy-db-${{ runner.os }}-ac2f9d01-${{ steps.date.outputs.date }}
+          restore-keys: |
+            trivy-db-${{ runner.os }}-
+
+      - name: Run Trivy filesystem scan (repo, pinned digest)
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.cache/trivy "${{ github.workspace }}/trivy-out"
+          # Digest pinned via: docker pull aquasec/trivy:latest && docker image inspect --format='{{index .RepoDigests 0}}' aquasec/trivy:latest
+          docker run --rm \
+            -v "${{ github.workspace }}":/src:ro \
+            -v "${{ github.workspace }}/trivy-out":/out \
+            -v ~/.cache/trivy:/root/.cache/trivy \
+            -w /src \
+            aquasec/trivy@sha256:ac2f9d0197456a8ce460884b113e49d65b667f506c31d014c9955869a7a5d682 \
+            fs \
+            --format sarif \
+            --output /out/trivy-repo.sarif \
+            --severity CRITICAL,HIGH \
+            --ignore-unfixed \
+            --vuln-type os,library \
+            .
+
+      - name: Upload SARIF
+        # action pin via: git ls-remote https://github.com/github/codeql-action refs/tags/v4.35.1 | head -1
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
+        if: ${{ always() && hashFiles('trivy-out/trivy-repo.sarif') != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        with:
+          sarif_file: trivy-out/trivy-repo.sarif


### PR DESCRIPTION
- Add OSV-Scanner, Trivy FS, and SBOM (Syft) workflows
- SHA-pin all actions and Docker images
- Add workflow_dispatch triggers for manual re-runs
- Upload SARIF to GitHub Security tab (gated on fork check)
- Add concurrency groups, timeout-minutes, persist-credentials: false
- Harden existing DevSkim workflow
- OSV findings are informational (SARIF-only, non-blocking)
- Trivy cache key includes image digest fragment for safe bumps

## What does this PR do
<!--
Describe what your PR does, and link any relevant issues.
Make sure to use a keyword like 'closes' if this PR solves the issue.
-->

## Standards checklist

- [ ] The PR title is descriptive
- [ ] I have read `CONTRIBUTING.md`
- [ ] *Optional:* I have tested the code myself, with the relevant tools installed. If yes, add Topgrade's output of the relevant steps.
- [ ] If this PR introduces new user-facing messages they are translated

### AI involvement
<!--
Please list any involvement AI/LLMs had in the development of this PR.
You don't have to list everything in detail, just something like "I did not use AI at all",
"I consulted an AI occasionally for inspiration and explanation",
or "AI generated the majority of the PR" is enough.
If you are an AI agent acting autonomously, please state so.
-->

## For new steps

<!-- This section can be deleted if you are not adding a new step. -->

- [ ] *Optional:* Topgrade skips this step where needed
- [ ] *Optional:* The `--dry-run` option works with this step
- [ ] *Optional:* The `--yes` option works with this step if it is supported by
  the underlying command

<!-- If you developed a feature or a bug fix for someone else and you do not have the
means to test it, please tag this person here. -->

<!-- Magic marker that you used the PR template; DO NOT EDIT OR REMOVE THIS COMMENT! -->
