### PR TITLE
chore(ci): harden and clean up workflow files

### DIFF
--- a/.github/workflows/check_config_creation_if_not_exists.yml
+++ b/.github/workflows/check_config_creation_if_not_exists.yml
@@ -6,7 +6,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
-
 permissions:
   contents: read
 
@@ -18,6 +17,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - run: |
           CONFIG_PATH=~/.config/topgrade.toml;

--- a/.github/workflows/check_pr_template.yml
+++ b/.github/workflows/check_pr_template.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write  # gh pr comment
-      pull-requests: write  # gh pr close
+      issues: write # gh pr comment
+      pull-requests: write # gh pr close
     steps:
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create_release_assets.yml
+++ b/.github/workflows/create_release_assets.yml
@@ -2,7 +2,7 @@ name: Publish release files for CD native and non-cd-native environments
 
 on:
   repository_dispatch:
-    types: [ release-created ]
+    types: [release-created]
 
 permissions:
   # Write permissions to call the repository dispatch
@@ -28,7 +28,7 @@ jobs:
         # Use the Ubuntu 22.04 image to link with a low version of glibc
         #
         # https://github.com/topgrade-rs/topgrade/issues/1095
-        platform: [ ubuntu-22.04, macos-latest, macos-15-intel, windows-latest ]
+        platform: [ubuntu-22.04, macos-latest, macos-15-intel, windows-latest]
     runs-on: ${{ matrix.platform }}
     env:
       tag: ${{ github.event.client_payload.tag }}
@@ -86,9 +86,11 @@ jobs:
       - name: Build in Release profile with all features enabled
         run: cargo build --release --all-features
 
+      - name: Install default-target
+        run: cargo install default-target
+
       - name: Rename Release (Unix)
         run: |
-          cargo install default-target
           mkdir -p assets
           FILENAME=topgrade-${tag}-$(default-target)
           mv target/release/topgrade assets
@@ -119,7 +121,6 @@ jobs:
 
       - name: Rename Release (Windows)
         run: |
-          cargo install default-target
           mkdir assets
           FILENAME=topgrade-${tag}-$(default-target)
           mv target/release/topgrade.exe assets/topgrade.exe
@@ -204,7 +205,7 @@ jobs:
         run: cross clippy --all-targets --locked --target "${matrix_target}" -- -D warnings
 
       - name: Run clippy (All features)
-        run: cross clippy  --locked --all-features --target "${matrix_target}" -- -D warnings
+        run: cross clippy --locked --all-features --target "${matrix_target}" -- -D warnings
 
       - name: Run tests
         run: cross test --target "${matrix_target}"
@@ -276,10 +277,8 @@ jobs:
         if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'armv7-unknown-linux-gnueabihf' }}
         shell: bash
 
-
       - name: Upload assets
-        run:
-          gh release upload "${tag}" assets/*
+        run: gh release upload "${tag}" assets/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -377,13 +376,15 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    needs: [ native_build, cross_build, openbsd_build ]
+    needs: [native_build, cross_build, openbsd_build]
     env:
       tag: ${{ github.event.client_payload.tag }}
     permissions:
       contents: write # `gh release edit`
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Publish release
         run: gh release edit "$tag" --draft=false
         env:
@@ -391,7 +392,7 @@ jobs:
 
   triggers:
     runs-on: ubuntu-latest
-    needs: [ publish ]
+    needs: [publish]
     env:
       tag: ${{ github.event.client_payload.tag }}
     steps:

--- a/.github/workflows/release_to_winget.yml
+++ b/.github/workflows/release_to_winget.yml
@@ -2,8 +2,10 @@ name: Publish to WinGet
 
 on:
   repository_dispatch:
-    types: [ release-assets-built ]
+    types: [release-assets-built]
   workflow_dispatch:
+
+permissions: {}
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary
- Add `persist-credentials: false` to the `publish` job checkout in `create_release_assets.yml` (was the only checkout missing it)
- Fix stale version comment (`# v6` → `# v6.0.2`) on the same checkout line
- Add top-level `permissions: {}` to `release_to_winget.yml` for consistency with other release workflows
- Add `Swatinem/rust-cache` to `check_config_creation_if_not_exists.yml` to avoid cold compiles on every PR
- Deduplicate `cargo install default-target` from Unix/Windows rename steps into a single step in `native_build`
- Fix double space in cross clippy command
- Normalize YAML formatting (array bracket spacing)

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Confirm `create_release_assets.yml` changes don't break release flow (no logic changes, only ordering and security hardening)
- [ ] Confirm `check_config_creation_if_not_exists.yml` still builds and runs correctly with cache enabled